### PR TITLE
Fixed type attribute key error.

### DIFF
--- a/backup_vm/parse.py
+++ b/backup_vm/parse.py
@@ -168,7 +168,7 @@ class Disk:
         # also be completely missing:
         # https://github.com/milkey-mouse/backup-vm/issues/11#issuecomment-351478233
         if xml.find("driver") is not None:
-            self.format = xml.find("driver").attrib["type"]
+            self.format = xml.find("driver").attrib.get("type", "unknown")
         else:
             self.format = "unknown"
 


### PR DESCRIPTION
Traceback (most recent call last):                                                                                                                                                             
  File "/usr/bin/backup-vm", line 11, in <module>                                              
    load_entry_point('backup-vm==0.1.dev28+g442ce38', 'console_scripts', 'backup-vm')() 
  File "/usr/lib/python3.8/site-packages/backup_vm-0.1.dev28+g442ce38-py3.8.egg/backup_vm/backup.py", line 24, in main                                                                         
    all_disks = set(parse.Disk.get_disks(dom))                                                                                                                                                 
  File "/usr/lib/python3.8/site-packages/backup_vm-0.1.dev28+g442ce38-py3.8.egg/backup_vm/parse.py", line 196, in get_disks                                                                    
    yield from {d for d in map(cls, tree.findall("devices/disk")) if d.type is not None}                                                                                                       
  File "/usr/lib/python3.8/site-packages/backup_vm-0.1.dev28+g442ce38-py3.8.egg/backup_vm/parse.py", line 196, in <setcomp>                                                                    
    yield from {d for d in map(cls, tree.findall("devices/disk")) if d.type is not None}                                                                                                       
  File "/usr/lib/python3.8/site-packages/backup_vm-0.1.dev28+g442ce38-py3.8.egg/backup_vm/parse.py", line 171, in __init__                                                                     
    self.format = xml.find("driver").attrib["type"]                                                                                                                                            
KeyError: 'type'